### PR TITLE
Refine website layout and separate styles

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,148 +3,45 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <title>Remonty Premium - Poznań</title>
-  <link rel="preconnect" href="https://fonts.googleapis.com">
-  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-  <link href="https://fonts.googleapis.com/css2?family=Playfair+Display:wght@600&family=Roboto:wght@400;500&display=swap" rel="stylesheet">
-  <style>
-    body {
-      margin: 0;
-      font-family: 'Roboto', sans-serif;
-      color: #222;
-      background-color: #f9f9f9;
-    }
-    header {
-      background-color: #111;
-      color: #fff;
-      padding: 20px 10%;
-      display: flex;
-      justify-content: space-between;
-      align-items: center;
-      flex-wrap: wrap;
-    }
-    header h1 {
-      font-family: 'Playfair Display', serif;
-      font-size: 2rem;
-      margin: 0;
-    }
-    header .info {
-      text-align: right;
-    }
-    section.hero {
-      background-image: url('https://source.unsplash.com/1600x900/?interior,apartment');
-      background-size: cover;
-      background-position: center;
-      height: 90vh;
-      display: flex;
-      align-items: center;
-      justify-content: center;
-      color: #fff;
-      text-shadow: 0 2px 5px rgba(0,0,0,0.6);
-      animation: fadeIn 1.5s ease-in;
-    }
-    .hero h2 {
-      font-size: 3rem;
-      background: rgba(0,0,0,0.5);
-      padding: 20px;
-      border-radius: 10px;
-    }
-    section.about {
-      padding: 60px 10%;
-      text-align: center;
-      animation: slideUp 1s ease-in;
-    }
-    .about h3 {
-      font-size: 2rem;
-      margin-bottom: 20px;
-      font-family: 'Playfair Display', serif;
-    }
-    .stats {
-      display: flex;
-      justify-content: space-around;
-      flex-wrap: wrap;
-      margin-top: 40px;
-    }
-    .stat {
-      margin: 20px;
-    }
-    .stat h4 {
-      font-size: 2rem;
-      color: #b28a4c;
-    }
-    footer {
-      background: #222;
-      color: #eee;
-      text-align: center;
-      padding: 40px 10%;
-      font-size: 0.9rem;
-    }
-    a {
-      color: #b28a4c;
-      text-decoration: none;
-    }
-    a:hover {
-      text-decoration: underline;
-    }
-
-    @keyframes fadeIn {
-      from {opacity: 0; transform: scale(1.05);}
-      to {opacity: 1; transform: scale(1);}
-    }
-    @keyframes slideUp {
-      from {opacity: 0; transform: translateY(50px);}
-      to {opacity: 1; transform: translateY(0);}
-    }
-    @media(max-width: 768px) {
-      header, section.about, footer {
-        padding: 20px;
-      }
-      .hero h2 {
-        font-size: 2rem;
-      }
-      .stats {
-        flex-direction: column;
-        align-items: center;
-      }
-    }
-  </style>
+  <title>RPP: Remonty premium Poznań</title>
+  <link rel="stylesheet" href="style.css" />
 </head>
 <body>
   <header>
-    <h1>Remonty Premium</h1>
+    <h1>RPP: Remonty premium Poznań</h1>
     <div class="info">
-      <p>Poznań i okolice</p>
-      <p>+48 123 456 789</p>
+      <p>Wykonawca: Łukasz Łukasz</p>
+      <p>Tel: 123 456 789</p>
     </div>
   </header>
 
   <section class="hero">
-    <h2>Wnętrza z charakterem</h2>
+    <h2>Wnętrza najwyższej jakości</h2>
   </section>
 
   <section class="about">
     <h3>O nas</h3>
-    <p>Specjalizujemy się w kompleksowych remontach i wykończeniach wnętrz klasy premium. Łączymy precyzję wykonania z eleganckim stylem, tworząc przestrzenie, które inspirują.</p>
-    <div class="stats">
-      <div class="stat">
-        <h4>10+</h4>
-        <p>lat na rynku</p>
-      </div>
-      <div class="stat">
-        <h4>350+</h4>
-        <p>zadowolonych klientów</p>
-      </div>
-      <div class="stat">
-        <h4>120+</h4>
-        <p>ukończonych projektów</p>
-      </div>
+    <p>Firma istnieje na rynku od ponad 10 lat. Obsłużyliśmy już setki zadowolonych klientów, dla których tworzymy eleganckie i funkcjonalne wnętrza. Nasz zespół nieustannie rozwija swoje umiejętności, dzięki czemu każda realizacja jest dopracowana w najmniejszym szczególe. Zachęcamy do obserwowania naszego profilu na Instagramie, gdzie prezentujemy aktualne projekty oraz inspiracje. Jesteśmy profesjonalistami specjalizującymi się w wykończeniach łazienek i kompleksowych remontach mieszkań.</p>
+  </section>
+
+  <section class="gallery">
+    <div class="photo">
+      <img src="Łazienka_01.jpg" alt="Łazienka 1" />
+      <p>Przykład minimalistycznego wykończenia</p>
+    </div>
+    <div class="photo">
+      <img src="Łazienka_02.jpg" alt="Łazienka 2" />
+      <p>Nowoczesne rozwiązania w jasnej tonacji</p>
+    </div>
+    <div class="photo">
+      <img src="Łazienka_03.jpg" alt="Łazienka 3" />
+      <p>Elegancka przestrzeń z akcentami drewna</p>
     </div>
   </section>
 
   <footer>
-    <p><strong>Remonty Premium</strong> • ul. Przykładowa 1, Poznań</p>
-    <p>Tel: +48 123 456 789 • <a href="#">Instagram</a></p>
-    <p>&copy; 2025 Wszystkie prawa zastrzeżone</p>
+    <p>Adres: ul. Przykładowa 1, Poznań</p>
+    <p>Tel: 123 456 789 • <a href="#">Instagram</a></p>
   </footer>
 </body>
 </html>

--- a/style.css
+++ b/style.css
@@ -1,0 +1,122 @@
+@import url('https://fonts.googleapis.com/css2?family=Playfair+Display:wght@600&family=Roboto:wght@400;500&display=swap');
+
+body {
+  margin: 0;
+  font-family: 'Roboto', sans-serif;
+  color: #222;
+  background-color: #f9f9f9;
+}
+
+header {
+  background-color: #111;
+  color: #fff;
+  padding: 20px 10%;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  flex-wrap: wrap;
+}
+header h1 {
+  font-family: 'Playfair Display', serif;
+  font-size: 2rem;
+  margin: 0;
+}
+header .info {
+  text-align: right;
+}
+
+.hero {
+  height: 90vh;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: #fff;
+  text-shadow: 0 2px 5px rgba(0,0,0,0.6);
+  animation: fadeIn 1.5s ease-in;
+  background-size: cover;
+  background-position: center;
+  animation: heroBackground 15s infinite;
+}
+.hero h2 {
+  font-size: 3rem;
+  background: rgba(0,0,0,0.5);
+  padding: 20px;
+  border-radius: 10px;
+}
+
+.about {
+  padding: 60px 10%;
+  text-align: center;
+  animation: slideUp 1s ease-in;
+}
+.about h3 {
+  font-size: 2rem;
+  margin-bottom: 20px;
+  font-family: 'Playfair Display', serif;
+}
+
+.gallery {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  gap: 20px;
+  padding: 40px 10%;
+}
+.gallery img {
+  width: 300px;
+  height: auto;
+  border-radius: 8px;
+  box-shadow: 0 2px 6px rgba(0,0,0,0.2);
+}
+.gallery p {
+  text-align: center;
+  margin: 10px 0 30px;
+}
+
+footer {
+  background: #222;
+  color: #eee;
+  text-align: center;
+  padding: 40px 10%;
+  font-size: 0.9rem;
+}
+a {
+  color: #b28a4c;
+  text-decoration: none;
+}
+a:hover {
+  text-decoration: underline;
+}
+
+@keyframes fadeIn {
+  from {opacity: 0; transform: scale(1.05);}
+  to {opacity: 1; transform: scale(1);}
+}
+@keyframes slideUp {
+  from {opacity: 0; transform: translateY(50px);}
+  to {opacity: 1; transform: translateY(0);}
+}
+@keyframes heroBackground {
+  0%, 33% {
+    background-image: url('Łazienka_01.jpg');
+  }
+  33%, 66% {
+    background-image: url('Łazienka_02.jpg');
+  }
+  66%, 100% {
+    background-image: url('Łazienka_03.jpg');
+  }
+}
+
+@media(max-width: 768px) {
+  header, .about, footer {
+    padding: 20px;
+  }
+  .hero h2 {
+    font-size: 2rem;
+  }
+  .gallery {
+    flex-direction: column;
+    align-items: center;
+  }
+}


### PR DESCRIPTION
## Summary
- separate HTML and CSS by adding `style.css`
- simplify `index.html` with header, hero section, about text, gallery and footer
- add animated background and responsive gallery

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6863b1d30da4833392ff03595496c689